### PR TITLE
Feat: Allow user to choose report mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,12 +188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,43 +261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "serde"
-version = "1.0.203"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.203"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,8 +295,6 @@ version = "0.1.1"
 dependencies = [
  "chrono",
  "clap",
- "serde",
- "serde_json",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,4 @@ path = "src/main.rs"
 [dependencies]
 chrono = "0.4.37"
 clap = "4.5.4"
-serde = { version = "1.0.203", features = ["derive"] }
-serde_json = "1.0.117"
 tempfile = "3.10.1"

--- a/src/cli/arg.rs
+++ b/src/cli/arg.rs
@@ -2,6 +2,7 @@ use super::app::options;
 use super::app::tree_app;
 use crate::config::root::BaseDirectory;
 use crate::error::simple::TResult;
+use crate::report::tail::ReportMode;
 use crate::walk::tr::TreeCtxt;
 
 use std::env;
@@ -45,7 +46,13 @@ impl TreeArgs {
         }
     }
 
-    pub fn match_app(&mut self, tr: &mut TreeCtxt, base_dir: &mut BaseDirectory) -> TResult<()> {
+    pub fn match_app(
+        &mut self,
+        tr: &mut TreeCtxt,
+        base_dir: &mut BaseDirectory,
+    ) -> TResult<ReportMode> {
+        let report_mode: ReportMode;
+
         let path_exist = extract_and_update_base_dir(&mut self.args, base_dir);
 
         if !path_exist {
@@ -73,6 +80,12 @@ impl TreeArgs {
             tr.rg.with_mtime()?;
             tr.rg.with_atime()?;
             tr.rg.with_size()?;
+        }
+
+        if matches.get_flag(options::report::YIELD) {
+            report_mode = ReportMode::Exhaustive
+        } else {
+            report_mode = ReportMode::Default
         }
 
         if matches.get_flag(options::sort::REVERSE) {
@@ -134,7 +147,7 @@ impl TreeArgs {
             tr.file_colors.disable_color();
         }
 
-        Ok(())
+        Ok(report_mode)
     }
 }
 

--- a/src/cli/arg.rs
+++ b/src/cli/arg.rs
@@ -2,7 +2,7 @@ use super::app::options;
 use super::app::tree_app;
 use crate::config::root::BaseDirectory;
 use crate::error::simple::TResult;
-use crate::report::tail::ReportMode;
+use crate::report::stats::ReportMode;
 use crate::walk::tr::TreeCtxt;
 
 use std::env;

--- a/src/config/inspect.rs
+++ b/src/config/inspect.rs
@@ -1,20 +1,20 @@
 use crate::error::simple::TResult;
-use crate::report::tail::Tail;
+use crate::report::stats::DirectoryStats;
 
 use std::fs;
 use std::fs::DirEntry;
 use std::path::PathBuf;
 
-pub type FnReadDir = fn(PathBuf, &mut Tail) -> TResult<Vec<DirEntry>>;
+pub type FnReadDir = fn(PathBuf, &mut DirectoryStats) -> TResult<Vec<DirEntry>>;
 
 #[allow(unused_variables)]
-pub fn read_all_entries(path: PathBuf, tail: &mut Tail) -> TResult<Vec<DirEntry>> {
+pub fn read_all_entries(path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
     let entries = fs::read_dir(path)?.collect::<Result<Vec<DirEntry>, std::io::Error>>()?;
 
     Ok(entries)
 }
 
-pub fn read_visible_entries(path: PathBuf, tail: &mut Tail) -> TResult<Vec<DirEntry>> {
+pub fn read_visible_entries(path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
     let entries = fs::read_dir(path)?
         .filter_map(|entry_result| {
             entry_result.ok().and_then(|entry| {
@@ -30,7 +30,7 @@ pub fn read_visible_entries(path: PathBuf, tail: &mut Tail) -> TResult<Vec<DirEn
     Ok(entries)
 }
 
-pub fn read_visible_folders(path: PathBuf, tail: &mut Tail) -> TResult<Vec<DirEntry>> {
+pub fn read_visible_folders(path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
     let entries = fs::read_dir(path)?
         .filter_map(|entry_result| {
             entry_result.ok().and_then(|entry| {

--- a/src/config/inspect.rs
+++ b/src/config/inspect.rs
@@ -7,21 +7,23 @@ use std::path::PathBuf;
 
 pub type FnReadDir = fn(PathBuf, &mut DirectoryStats) -> TResult<Vec<DirEntry>>;
 
-#[allow(unused_variables)]
-pub fn read_all_entries(path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
+pub fn read_all_entries(path: PathBuf, _dir_stats: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
     let entries = fs::read_dir(path)?.collect::<Result<Vec<DirEntry>, std::io::Error>>()?;
 
     Ok(entries)
 }
 
-pub fn read_visible_entries(path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
+pub fn read_visible_entries(
+    path: PathBuf,
+    dir_stats: &mut DirectoryStats,
+) -> TResult<Vec<DirEntry>> {
     let entries = fs::read_dir(path)?
         .filter_map(|entry_result| {
             entry_result.ok().and_then(|entry| {
                 if !entry.file_name().to_string_lossy().starts_with('.') {
                     Some(entry)
                 } else {
-                    tail.hidden_add_one();
+                    dir_stats.hidden_add_one();
                     None
                 }
             })
@@ -30,7 +32,10 @@ pub fn read_visible_entries(path: PathBuf, tail: &mut DirectoryStats) -> TResult
     Ok(entries)
 }
 
-pub fn read_visible_folders(path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
+pub fn read_visible_folders(
+    path: PathBuf,
+    dir_stats: &mut DirectoryStats,
+) -> TResult<Vec<DirEntry>> {
     let entries = fs::read_dir(path)?
         .filter_map(|entry_result| {
             entry_result.ok().and_then(|entry| {
@@ -38,7 +43,7 @@ pub fn read_visible_folders(path: PathBuf, tail: &mut DirectoryStats) -> TResult
                 if metadata.is_dir() && !entry.file_name().to_string_lossy().starts_with('.') {
                     Some(entry)
                 } else {
-                    tail.hidden_add_one();
+                    dir_stats.hidden_add_one();
                     None
                 }
             })

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -18,7 +18,7 @@ use crate::render::entree::dirr::FnOutDir;
 use crate::render::entree::filee::FnOutFile;
 use crate::render::entree::headd::FnOutHead;
 use crate::render::entree::symlinked::FnOutSymlink;
-use crate::report::tail::Tail;
+use crate::report::stats::DirectoryStats;
 
 use std::fs::DirEntry;
 use std::io::StdoutLock;
@@ -44,7 +44,7 @@ pub struct Registry<'a> {
 }
 
 impl<'a> Registry<'a> {
-    pub fn inspt_dents(&self, path: PathBuf, tail: &mut Tail) -> TResult<Vec<DirEntry>> {
+    pub fn inspt_dents(&self, path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
         (self.read)(path, tail)
     }
 

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -44,8 +44,8 @@ pub struct Registry<'a> {
 }
 
 impl<'a> Registry<'a> {
-    pub fn inspt_dents(&self, path: PathBuf, tail: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
-        (self.read)(path, tail)
+    pub fn inspt_dents(&self, path: PathBuf, dir_stats: &mut DirectoryStats) -> TResult<Vec<DirEntry>> {
+        (self.read)(path, dir_stats)
     }
 
     pub fn sort_dents(&self, entries: &mut Vec<DirEntry>) {

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -30,7 +30,7 @@ pub struct Registry<'a> {
     // Common util
     pub read: FnReadDir,
     pub sort: FnSortEntries,
-    /// Entry  
+    // Entry
     pub dir: FnOutDir<StdoutLock<'a>>,
     pub file: FnOutFile<StdoutLock<'a>>,
     pub symlink: FnOutSymlink<StdoutLock<'a>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use crate::cli::arg::TreeArgs;
 
 mod config;
 use config::root::BaseDirectory;
-use report::tail::ReportMode;
+use report::stats::ReportMode;
 
 mod error;
 use crate::error::simple::TResult;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use crate::cli::arg::TreeArgs;
 
 mod config;
 use config::root::BaseDirectory;
+use report::tail::ReportMode;
 
 mod error;
 use crate::error::simple::TResult;
@@ -21,18 +22,18 @@ fn main() -> TResult<()> {
     let mut tr = TreeCtxt::new()?;
     let mut base_dir = BaseDirectory::from_current_dir()?;
 
-    args.match_app(&mut tr, &mut base_dir)?;
+    let report_mode = args.match_app(&mut tr, &mut base_dir)?;
 
     // Update path_builder based on base_dir
     tr.path_builder = base_dir.build().expect("Cannot build base directory.");
     tr.path_builder.append_root();
 
-    run_tree(&mut tr)?;
+    run_tree(&mut tr, report_mode)?;
 
     Ok(())
 }
 
-fn run_tree(tr: &mut TreeCtxt) -> TResult<()> {
+fn run_tree(tr: &mut TreeCtxt, report_mode: ReportMode) -> TResult<()> {
     tr.print_head(
         tr.path_builder.filename(),
         tr.path_builder.base_path(),
@@ -41,7 +42,7 @@ fn run_tree(tr: &mut TreeCtxt) -> TResult<()> {
 
     tr.walk_dir(tr.path_builder.base_path())?;
 
-    tr.print_report()?;
+    tr.print_report(report_mode)?;
 
     Ok(())
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,4 +1,4 @@
 pub mod depth;
 pub mod size;
-pub mod tail;
+pub mod stats;
 pub mod widest;

--- a/src/report/stats.rs
+++ b/src/report/stats.rs
@@ -7,7 +7,7 @@ pub enum ReportMode {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Tail {
+pub struct DirectoryStats {
     directories: usize,
     files: usize,
     hidden_files: usize,
@@ -17,9 +17,9 @@ pub struct Tail {
     size: u64,
 }
 
-impl Default for Tail {
+impl Default for DirectoryStats {
     fn default() -> Self {
-        Tail {
+        DirectoryStats {
             directories: 1,
             files: 0,
             size: 0,
@@ -31,7 +31,7 @@ impl Default for Tail {
     }
 }
 
-impl Tail {
+impl DirectoryStats {
     pub fn dir_add_one(&mut self) {
         self.directories += 1
     }
@@ -85,7 +85,7 @@ impl ReportSummary {
     }
 }
 
-impl Tail {
+impl DirectoryStats {
     pub fn populate_report(&self, report_summary: &mut ReportSummary, report_mode: ReportMode) {
         let directories = self.directories_to_string().unwrap();
         let directories = format!("{}: {}", directories.1, directories.0);
@@ -126,7 +126,7 @@ impl Tail {
 }
 
 #[allow(unused_assignments, dead_code)]
-impl Tail {
+impl DirectoryStats {
     fn directories_to_string(&self) -> TResult<(String, String)> {
         let mut dir_str = String::new();
 

--- a/src/report/tail.rs
+++ b/src/report/tail.rs
@@ -1,5 +1,11 @@
 use crate::error::simple::TResult;
 
+#[derive(PartialEq)]
+pub enum ReportMode {
+    Default,
+    Exhaustive,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Tail {
     directories: usize,
@@ -22,187 +28,6 @@ impl Default for Tail {
             total_items: 0,
             special_files: 0,
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ReportSummary {
-    report: Vec<String>,
-}
-
-impl ReportSummary {
-    pub fn with_capacity(cap: i32) -> TResult<Self> {
-        Ok(ReportSummary {
-            report: Vec::with_capacity(cap as usize),
-        })
-    }
-
-    pub fn push(&mut self, str: String) {
-        self.report.push(str);
-    }
-
-    pub fn join(&self, str: &str) -> String {
-        self.report.join(str)
-    }
-}
-
-impl Tail {
-    pub fn parse_report(&self, report_summary: &mut ReportSummary) {
-        let dir = self.directories_to_string().unwrap();
-        let directories = format!("{}: {}", dir.1, dir.0);
-
-        let files = self.files_to_string().unwrap();
-        let files = format!("{}: {}", files.1, files.0);
-
-        let hidden_files = self.hidden_files_to_string().unwrap();
-        let hidden_files = format!("{}: {}", hidden_files.1, hidden_files.0);
-
-        let symlinks = self.symlinks_to_string().unwrap();
-        let symlinks = format!("{}: {}", symlinks.1, symlinks.0);
-
-        let special_files = self.special_files_to_string().unwrap();
-        let special_files = format!("{}: {}", special_files.1, special_files.0);
-
-        let total_items = self.total_items_to_string().unwrap();
-        let total_items = format!("{}: {}", total_items.1, total_items.0);
-
-        let size = self.size_to_string().unwrap();
-        let size = format!("{}: {}", size.1, size.0);
-
-        report_summary.push(directories);
-        report_summary.push(files);
-        report_summary.push(hidden_files);
-        report_summary.push(symlinks);
-        report_summary.push(special_files);
-        report_summary.push(total_items);
-        report_summary.push(size);
-    }
-}
-
-#[allow(unused_assignments, dead_code)]
-impl Tail {
-    pub fn directories_to_string(&self) -> TResult<(String, String)> {
-        let mut dir_str = String::new();
-
-        let directories = self.directories;
-
-        if directories > 1 {
-            dir_str = "Directories".to_string();
-        } else {
-            dir_str = "Directory".to_string();
-        }
-
-        let dir_count = format!("{}", directories);
-
-        Ok((dir_count, dir_str))
-    }
-
-    pub fn files_to_string(&self) -> TResult<(String, String)> {
-        let mut file_str = String::new();
-
-        let files = self.files;
-
-        if files > 1 {
-            file_str = "Files".to_string();
-        } else {
-            file_str = "File".to_string();
-        }
-
-        let file_count = format!("{}", files);
-
-        Ok((file_count, file_str))
-    }
-
-    pub fn hidden_files_to_string(&self) -> TResult<(String, String)> {
-        let mut hidden_files_str = String::new();
-
-        let hidden_files = self.hidden_files;
-
-        if hidden_files > 1 {
-            hidden_files_str = "Hidden Files".to_string();
-        } else {
-            hidden_files_str = "Hidden File".to_string();
-        }
-
-        let hidden_files_count = format!("{}", hidden_files);
-
-        Ok((hidden_files_count, hidden_files_str))
-    }
-
-    pub fn symlinks_to_string(&self) -> TResult<(String, String)> {
-        let mut symlinks_str = String::new();
-
-        let symlinks = self.symlinks;
-
-        if symlinks > 1 {
-            symlinks_str = "Symlinks".to_string();
-        } else {
-            symlinks_str = "Symlink".to_string();
-        }
-
-        let symlinks_count = format!("{}", symlinks);
-
-        Ok((symlinks_count, symlinks_str))
-    }
-
-    pub fn special_files_to_string(&self) -> TResult<(String, String)> {
-        let mut special_files_str = String::new();
-
-        let special_files = self.special_files;
-
-        if special_files > 1 {
-            special_files_str = "Special Files".to_string();
-        } else {
-            special_files_str = "Special File".to_string();
-        }
-
-        let special_files_count = format!("{}", special_files);
-
-        Ok((special_files_count, special_files_str))
-    }
-
-    pub fn total_items_to_string(&self) -> TResult<(String, String)> {
-        let mut total_items_str = String::new();
-
-        let total_items = self.total_items;
-
-        if total_items > 1 {
-            total_items_str = "Total Items".to_string();
-        } else {
-            total_items_str = "Total Item".to_string();
-        }
-
-        let total_items_count = format!("{}", total_items);
-
-        Ok((total_items_count, total_items_str))
-    }
-
-    pub fn size_to_string(&self) -> TResult<(String, String)> {
-        let size = self.size as f64;
-        let size_count: f64;
-
-        let mut unit_count = String::new();
-        let mut unit_str = String::new();
-
-        let two_gb_in_bytes = 2.0 * 1024.0 * 1024.0 * 1024.0; // 2147483648.0 @ 2 gigabytes
-
-        let one_gb_in_bytes = 1.0 * 1024.0 * 1024.0 * 1024.0; // 1073741824.0 @ 1 gigabyte
-
-        if size > two_gb_in_bytes {
-            unit_str = "Gigabytes".to_string();
-            size_count = size / 1_073_741_824.0;
-            unit_count = format!("{:.3}", size_count);
-        } else if size < two_gb_in_bytes && size > one_gb_in_bytes {
-            unit_str = "Gigabyte".to_string();
-            size_count = size / 1_073_741_824.0;
-            unit_count = format!("{:.3}", size_count);
-        } else if size < one_gb_in_bytes {
-            unit_str = "bytes".to_string();
-            size_count = size;
-            unit_count = format!("{}", size_count);
-        }
-
-        Ok((unit_count, unit_str))
     }
 }
 
@@ -236,5 +61,187 @@ impl Tail {
     /// If user want to include hidden files, pass `--all` in the arguments
     pub fn accumulate_items(&mut self) {
         self.total_items = self.directories + self.files + self.symlinks + self.special_files;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReportSummary {
+    report: Vec<String>,
+}
+
+impl ReportSummary {
+    pub fn with_capacity(cap: i32) -> TResult<Self> {
+        Ok(ReportSummary {
+            report: Vec::with_capacity(cap as usize),
+        })
+    }
+
+    pub fn push(&mut self, str: String) {
+        self.report.push(str);
+    }
+
+    pub fn join(&self, str: &str) -> String {
+        self.report.join(str)
+    }
+}
+
+impl Tail {
+    pub fn populate_report(&self, report_summary: &mut ReportSummary, report_mode: ReportMode) {
+        let directories = self.directories_to_string().unwrap();
+        let directories = format!("{}: {}", directories.1, directories.0);
+
+        let files = self.files_to_string().unwrap();
+        let files = format!("{}: {}", files.1, files.0);
+
+        let hidden_files = self.hidden_files_to_string().unwrap();
+        let hidden_files = format!("{}: {}", hidden_files.1, hidden_files.0);
+
+        let symlinks = self.symlinks_to_string().unwrap();
+        let symlinks = format!("{}: {}", symlinks.1, symlinks.0);
+
+        let special_files = self.special_files_to_string().unwrap();
+        let special_files = format!("{}: {}", special_files.1, special_files.0);
+
+        let total_items = self.total_items_to_string().unwrap();
+        let total_items = format!("{}: {}", total_items.1, total_items.0);
+
+        let size = self.size_to_string().unwrap();
+        let size = format!("Sizes: {} {}", size.0, size.1);
+
+        if report_mode == ReportMode::Default {
+            report_summary.push(directories);
+            report_summary.push(files);
+            report_summary.push(symlinks);
+            report_summary.push(size);
+        } else {
+            report_summary.push(directories);
+            report_summary.push(files);
+            report_summary.push(hidden_files);
+            report_summary.push(symlinks);
+            report_summary.push(special_files);
+            report_summary.push(total_items);
+            report_summary.push(size);
+        }
+    }
+}
+
+#[allow(unused_assignments, dead_code)]
+impl Tail {
+    fn directories_to_string(&self) -> TResult<(String, String)> {
+        let mut dir_str = String::new();
+
+        let directories = self.directories;
+
+        if directories > 1 {
+            dir_str = "Directories".to_string();
+        } else {
+            dir_str = "Directory".to_string();
+        }
+
+        let dir_count = format!("{}", directories);
+
+        Ok((dir_count, dir_str))
+    }
+
+    fn files_to_string(&self) -> TResult<(String, String)> {
+        let mut file_str = String::new();
+
+        let files = self.files;
+
+        if files > 1 {
+            file_str = "Files".to_string();
+        } else {
+            file_str = "File".to_string();
+        }
+
+        let file_count = format!("{}", files);
+
+        Ok((file_count, file_str))
+    }
+
+    fn hidden_files_to_string(&self) -> TResult<(String, String)> {
+        let hidden_files_str = "Hidden".to_string();
+
+        let hidden_files = self.hidden_files;
+
+        let hidden_files_count = format!("{}", hidden_files);
+
+        Ok((hidden_files_count, hidden_files_str))
+    }
+
+    fn symlinks_to_string(&self) -> TResult<(String, String)> {
+        let mut symlinks_str = String::new();
+
+        let symlinks = self.symlinks;
+
+        if symlinks > 1 {
+            symlinks_str = "Symlinks".to_string();
+        } else {
+            symlinks_str = "Symlink".to_string();
+        }
+
+        let symlinks_count = format!("{}", symlinks);
+
+        Ok((symlinks_count, symlinks_str))
+    }
+
+    fn special_files_to_string(&self) -> TResult<(String, String)> {
+        let mut special_files_str = String::new();
+
+        let special_files = self.special_files;
+
+        if special_files > 1 {
+            special_files_str = "Special Files".to_string();
+        } else {
+            special_files_str = "Special File".to_string();
+        }
+
+        let special_files_count = format!("{}", special_files);
+
+        Ok((special_files_count, special_files_str))
+    }
+
+    fn total_items_to_string(&self) -> TResult<(String, String)> {
+        let mut total_items_str = String::new();
+
+        let total_items = self.total_items;
+
+        if total_items > 1 {
+            total_items_str = "Total Items".to_string();
+        } else {
+            total_items_str = "Total Item".to_string();
+        }
+
+        let total_items_count = format!("{}", total_items);
+
+        Ok((total_items_count, total_items_str))
+    }
+
+    fn size_to_string(&self) -> TResult<(String, String)> {
+        let size = self.size as f64;
+        let size_count: f64;
+
+        let mut unit_count = String::new();
+        let mut unit_str = String::new();
+
+        let two_gb_in_bytes = 2.0 * 1024.0 * 1024.0 * 1024.0; // 2147483648.0 @ 2 gigabytes
+
+        let one_gb_in_bytes = 1.0 * 1024.0 * 1024.0 * 1024.0; // 1073741824.0 @ 1 gigabyte
+
+        if size > two_gb_in_bytes {
+            unit_str = "Gigabytes".to_string();
+            size_count = size / 1_073_741_824.0;
+            unit_count = format!("{:.3}", size_count);
+        } else if size < two_gb_in_bytes && size > one_gb_in_bytes {
+            unit_str = "Gigabyte".to_string();
+            size_count = size / 1_073_741_824.0;
+            unit_count = format!("{:.3}", size_count);
+        } else if size < one_gb_in_bytes {
+            unit_str = "bytes".to_string();
+            size_count = size;
+            unit_count = format!("{}", size_count);
+        }
+
+        Ok((unit_count, unit_str))
     }
 }

--- a/src/walk/tr.rs
+++ b/src/walk/tr.rs
@@ -3,7 +3,7 @@ use crate::config::registry::Registry;
 use crate::config::root::PathBuilder;
 use crate::error::simple::TResult;
 use crate::render::buffer::Buffer;
-use crate::report::tail::{ReportSummary, Tail};
+use crate::report::tail::{ReportMode, ReportSummary, Tail};
 use crate::tree::branch::Branch;
 use crate::tree::level::Level;
 use crate::tree::node::Node;
@@ -188,17 +188,13 @@ impl<'tr> TreeCtxt<'tr> {
         Ok(())
     }
 
-    pub fn print_report(&mut self) -> TResult<()> {
+    pub fn print_report(&mut self, report_mode: ReportMode) -> TResult<()> {
         self.buf.newline()?;
 
         self.tail.accumulate_items();
-
         let mut report_summary = ReportSummary::with_capacity(50).unwrap();
-
-        self.tail.parse_report(&mut report_summary);
-
+        self.tail.populate_report(&mut report_summary, report_mode);
         let summary = report_summary.join(", ");
-
         self.buf.write_message(&summary)?;
 
         self.buf.newline()?;

--- a/src/walk/tr.rs
+++ b/src/walk/tr.rs
@@ -3,7 +3,9 @@ use crate::config::registry::Registry;
 use crate::config::root::PathBuilder;
 use crate::error::simple::TResult;
 use crate::render::buffer::Buffer;
-use crate::report::tail::{ReportMode, ReportSummary, Tail};
+use crate::report::stats::DirectoryStats;
+use crate::report::stats::ReportMode;
+use crate::report::stats::ReportSummary;
 use crate::tree::branch::Branch;
 use crate::tree::level::Level;
 use crate::tree::node::Node;
@@ -22,7 +24,7 @@ pub struct TreeCtxt<'tr> {
     pub level: Level,
     pub nod: Node,
     pub rg: Registry<'tr>,
-    pub tail: Tail,
+    pub tail: DirectoryStats,
     pub file_colors: FileColors,
     pub path_builder: PathBuilder,
 }
@@ -32,7 +34,7 @@ impl<'tr> TreeCtxt<'tr> {
         let buf = Buffer::new(io::stdout().lock())?;
         let branch = Branch::default();
         let nod = Node::default();
-        let tail = Tail::default();
+        let tail = DirectoryStats::default();
         let level = Level::default();
         let rg = Registry::new()?;
         let file_colors = FileColors::new();


### PR DESCRIPTION
- User can now choose whether to show `exhaustive` or `default` mode when printing a report with passing `-y` or `--yield` to `trees-rs`.
- Implement our methods to extract directory statistics and remove serde implementation

Note: In the future, we may implement a more robust summary statistic.